### PR TITLE
Lbr server exception handling

### DIFF
--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/EventStore.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/EventStore.java
@@ -8,7 +8,7 @@ import de.nuttercode.androidprojectss2018.csi.query.LBRQuery;
  * @author Johannes B. Latzel
  *
  */
-public class EventStore extends Store<ScoredEvent> {
+public class EventStore extends Store<ScoredEvent, LBRQuery> {
 
 	/**
 	 * @param clientConfiguration
@@ -26,9 +26,8 @@ public class EventStore extends Store<ScoredEvent> {
 	 * @param longitude
 	 */
 	public void setUserLocation(double latitude, double longitude) {
-		LBRQuery lbrQuery = (LBRQuery) query;
-		lbrQuery.setLatitude(latitude);
-		lbrQuery.setLongitude(longitude);
+		query.setLatitude(latitude);
+		query.setLongitude(longitude);
 	}
 
 }

--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/Store.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/Store.java
@@ -22,10 +22,10 @@ import de.nuttercode.androidprojectss2018.csi.query.QueryResultSummary;
  * @param <T>
  *            some {@link Serializable}
  */
-public class Store<T extends Serializable> {
+public class Store<T extends Serializable, Q extends Query<T>> {
 
 	private final Set<T> tSet;
-	protected final Query<T> query;
+	protected final Q query;
 	private final List<StoreListener<T>> storeListenerList;
 
 	/**
@@ -33,7 +33,7 @@ public class Store<T extends Serializable> {
 	 * @throws IllegalArgumentException
 	 *             if query is null
 	 */
-	protected Store(Query<T> query) {
+	protected Store(Q query) {
 		Assurance.assureNotNull(query);
 		tSet = new HashSet<>();
 		this.query = query;

--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/Store.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/Store.java
@@ -60,7 +60,7 @@ public class Store<T extends Serializable> {
 		QueryResultSummary<T> resultSummary = query.run();
 		QueryResultInformation resultInformation = resultSummary.getQueryResultInformation();
 		Collection<T> receivedElements;
-		if (resultInformation.getQueryResultState() == QueryResultState.OK) {
+		if (resultInformation.isOK()) {
 			receivedElements = resultSummary.getQueryResult().getAll();
 			for (T newElement : receivedElements)
 				if (!tSet.contains(newElement))

--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/TagStore.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/TagStore.java
@@ -9,7 +9,7 @@ import de.nuttercode.androidprojectss2018.csi.query.TagQuery;
  * @author Johannes B. Latzel
  *
  */
-public class TagStore extends Store<Tag> {
+public class TagStore extends Store<Tag, TagQuery> {
 
 	/**
 	 * @param clientConfiguration

--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/query/QueryResponse.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/query/QueryResponse.java
@@ -3,7 +3,16 @@ package de.nuttercode.androidprojectss2018.csi.query;
 import java.io.Serializable;
 
 import de.nuttercode.androidprojectss2018.csi.Assurance;
+import de.nuttercode.androidprojectss2018.lbrserver.LBRServer;
 
+/**
+ * encapsulates {@link QueryResult} and {@link QueryResultState} as send by
+ * {@link LBRServer}
+ * 
+ * @author Johannes B. Latzel
+ *
+ * @param <T>
+ */
 public class QueryResponse<T extends Serializable> implements Serializable {
 
 	private static final long serialVersionUID = -3074134072459244746L;

--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/query/QueryResponse.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/query/QueryResponse.java
@@ -1,0 +1,35 @@
+package de.nuttercode.androidprojectss2018.csi.query;
+
+import java.io.Serializable;
+
+import de.nuttercode.androidprojectss2018.csi.Assurance;
+
+public class QueryResponse<T extends Serializable> implements Serializable {
+
+	private static final long serialVersionUID = -3074134072459244746L;
+
+	private final QueryResult<T> queryResult;
+	private final QueryResultState serverQueryResultState;
+
+	public QueryResponse(QueryResult<T> queryResult, QueryResultState serverQueryResultState) {
+		Assurance.assureNotNull(queryResult);
+		Assurance.assureNotNull(serverQueryResultState);
+		this.queryResult = queryResult;
+		this.serverQueryResultState = serverQueryResultState;
+	}
+
+	@Override
+	public String toString() {
+		return "LBRQueryResponse [queryResult=" + queryResult + ", serverQueryResultState=" + serverQueryResultState
+				+ "]";
+	}
+
+	public QueryResult<T> getQueryResult() {
+		return queryResult;
+	}
+
+	public QueryResultState getServerQueryResultState() {
+		return serverQueryResultState;
+	}
+
+}

--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/query/QueryResultInformation.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/query/QueryResultInformation.java
@@ -3,34 +3,51 @@ package de.nuttercode.androidprojectss2018.csi.query;
 import de.nuttercode.androidprojectss2018.csi.Assurance;
 
 /**
- * encapsulates a state and a message of some {@link Query}
+ * encapsulates a state and a message of some {@link QueryResponse}
  * 
  * @author Johannes B. Latzel
  *
  */
 public class QueryResultInformation {
 
-	private final QueryResultState queryResultState;
+	private final QueryResultState clientQueryResultState;
+	private final QueryResultState serverQueryResultState;
 	private final String message;
 
-	public QueryResultInformation(QueryResultState queryResultState, String message) {
-		Assurance.assureNotNull(queryResultState);
+	public QueryResultInformation(QueryResultState clientQueryResultState, QueryResultState serverQueryResultState,
+			String message) {
+		Assurance.assureNotNull(clientQueryResultState);
+		Assurance.assureNotNull(serverQueryResultState);
 		Assurance.assureNotEmpty(message);
-		this.queryResultState = queryResultState;
+		this.clientQueryResultState = clientQueryResultState;
+		this.serverQueryResultState = serverQueryResultState;
 		this.message = message;
 	}
 
-	public QueryResultState getQueryResultState() {
-		return queryResultState;
+	public QueryResultState getClientQueryResultState() {
+		return clientQueryResultState;
 	}
 
 	public String getMessage() {
 		return message;
 	}
 
+	public QueryResultState getServerQueryResultState() {
+		return serverQueryResultState;
+	}
+
+	/**
+	 * @return true if {@link #getServerQueryResultState()} and
+	 *         {@link #clientQueryResultState} are {@link QueryResultState#OK}
+	 */
+	public boolean isOK() {
+		return serverQueryResultState == QueryResultState.OK && clientQueryResultState == QueryResultState.OK;
+	}
+
 	@Override
 	public String toString() {
-		return "QueryResultInformation [queryResultState=" + queryResultState + ", message=" + message + "]";
+		return "QueryResultInformation [clientQueryResultState=" + clientQueryResultState + ", serverQueryResultState="
+				+ serverQueryResultState + ", message=" + message + "]";
 	}
 
 }

--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/query/QueryResultState.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/query/QueryResultState.java
@@ -1,5 +1,5 @@
 package de.nuttercode.androidprojectss2018.csi.query;
 
 public enum QueryResultState {
-	OK, ClassNotFoundException, UnknownHostException, IOException, RuntimeException, InterruptedException, Null, ClassCastException
+	OK, ClassNotFoundException, UnknownHostException, IOException, RuntimeException, InterruptedException, Null, ClassCastException, SQLException
 }

--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/query/ServerConnection.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/query/ServerConnection.java
@@ -2,6 +2,7 @@ package de.nuttercode.androidprojectss2018.csi.query;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
@@ -63,6 +64,20 @@ public class ServerConnection implements Closeable {
 	}
 
 	/**
+	 * @return the next object read from the {@link InputStream} of the
+	 *         {@link #socket}
+	 * @throws ClassNotFoundException
+	 *             when {@link ObjectInputStream#readObject()} does
+	 * @throws IOException
+	 *             when {@link ObjectInputStream#readObject()} does
+	 */
+	private Object readObject() throws ClassNotFoundException, IOException {
+		if (objectInputStream == null)
+			objectInputStream = new ObjectInputStream(socket.getInputStream());
+		return objectInputStream.readObject();
+	}
+
+	/**
 	 * writes the {@link Query} to the {@link OutputStream} of the {@link #socket}
 	 * 
 	 * @param query
@@ -75,16 +90,16 @@ public class ServerConnection implements Closeable {
 	}
 
 	/**
-	 * reads the {@link QueryResult} of the answer of the {@link LBRServer} from the
-	 * {@link InputStream} of the {@link #socket}
+	 * reads the {@link QueryResultState} of the answer of the {@link LBRServer}
+	 * from the {@link InputStream} of the {@link #socket}
 	 * 
 	 * @throws IOException
-	 *             when {@link ObjectInputStream#readObject()} does
+	 *             when {@link #readObject()} does
+	 * @throws ClassNotFoundException
+	 *             when {@link #readObject()} does
 	 */
-	public QueryResult<?> readResult() throws ClassNotFoundException, IOException, InterruptedException {
-		if (objectInputStream == null)
-			objectInputStream = new ObjectInputStream(socket.getInputStream());
-		return (QueryResult<?>) objectInputStream.readObject();
+	public QueryResponse<?> readResponse() throws ClassNotFoundException, IOException {
+		return (QueryResponse<?>) readObject();
 	}
 
 	@Override

--- a/Backend/src/de/nuttercode/androidprojectss2018/example/LBRQueryExample.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/example/LBRQueryExample.java
@@ -3,7 +3,6 @@ package de.nuttercode.androidprojectss2018.example;
 import de.nuttercode.androidprojectss2018.csi.ClientConfiguration;
 import de.nuttercode.androidprojectss2018.csi.EventStore;
 import de.nuttercode.androidprojectss2018.csi.ScoredEvent;
-import de.nuttercode.androidprojectss2018.csi.query.QueryResultState;
 
 /**
  * example for LBRQuery connection
@@ -22,7 +21,7 @@ public class LBRQueryExample {
 		eventStore.addStoreListener(new StoreListenerExample<>());
 
 		// blocking until tags received or timeout
-		if (eventStore.refresh().getQueryResultState() == QueryResultState.OK)
+		if (eventStore.refresh().isOK())
 			for (ScoredEvent scoredEvent : eventStore.getAll())
 				System.out.println(scoredEvent);
 

--- a/Backend/src/de/nuttercode/androidprojectss2018/example/TagQueryExample.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/example/TagQueryExample.java
@@ -3,7 +3,6 @@ package de.nuttercode.androidprojectss2018.example;
 import de.nuttercode.androidprojectss2018.csi.ClientConfiguration;
 import de.nuttercode.androidprojectss2018.csi.Tag;
 import de.nuttercode.androidprojectss2018.csi.TagStore;
-import de.nuttercode.androidprojectss2018.csi.query.QueryResultState;
 
 /**
  * Test LBRClient connection
@@ -22,7 +21,7 @@ public class TagQueryExample {
 		tagStore.addStoreListener(new StoreListenerExample<>());
 
 		// blocking until tags received or timeout
-		if (tagStore.refresh().getQueryResultState() == QueryResultState.OK)
+		if (tagStore.refresh().isOK())
 			for (Tag tag : tagStore.getAll())
 				System.out.println(tag);
 

--- a/Backend/src/de/nuttercode/androidprojectss2018/lbrserver/ClientListener.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/lbrserver/ClientListener.java
@@ -27,6 +27,12 @@ public class ClientListener implements Closeable {
 	private final static int SERVER_SOCKET_TIMEOUT = 30_000;
 
 	/**
+	 * max time in milliseconds a {@link #getRequest()} will wait for the
+	 * {@link #pendingClientQueue} to be filled with at least 1 pending connection
+	 */
+	private final static int PENDING_QUEUE_WAIT = 5_000;
+
+	/**
 	 * used to accept LBRClient connections
 	 */
 	private final ServerSocket serverSocket;
@@ -95,7 +101,7 @@ public class ClientListener implements Closeable {
 	public Socket getRequest() throws InterruptedException {
 		synchronized (pendingClientQueue) {
 			while (pendingClientQueue.isEmpty())
-				pendingClientQueue.wait();
+				pendingClientQueue.wait(PENDING_QUEUE_WAIT);
 			return pendingClientQueue.poll();
 		}
 	}

--- a/Backend/src/de/nuttercode/androidprojectss2018/test/DBConnectionTest.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/test/DBConnectionTest.java
@@ -20,12 +20,13 @@ public class DBConnectionTest {
 	public static void main(String[] args) {
 		try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
 			System.out.print("enter password: ");
-			DBConnection dbConnection = new DBConnection("jdbc:mysql://lbr.nuttercode.de:3306/lbr", "lbr",
-					reader.readLine());
-			for (Tag tag : dbConnection.getAllTags())
-				System.out.println(tag);
-			for (Event event : dbConnection.getAllEventsByRadiusAndLocation(10, 52.3, 8.05))
-				System.out.println(event);
+			try (DBConnection dbConnection = new DBConnection("jdbc:mysql://lbr.nuttercode.de:3306/lbr", "lbr",
+					reader.readLine())) {
+				for (Tag tag : dbConnection.getAllTags())
+					System.out.println(tag);
+				for (Event event : dbConnection.getAllEventsByRadiusAndLocation(10, 52.3, 8.05))
+					System.out.println(event);
+			}
 		} catch (SQLException e) {
 			e.printStackTrace();
 		} catch (IOException e1) {

--- a/Backend/src/de/nuttercode/androidprojectss2018/test/LBRQueryTest.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/test/LBRQueryTest.java
@@ -6,7 +6,6 @@ import de.nuttercode.androidprojectss2018.csi.ClientConfiguration;
 import de.nuttercode.androidprojectss2018.csi.EventStore;
 import de.nuttercode.androidprojectss2018.csi.Tag;
 import de.nuttercode.androidprojectss2018.csi.TagStore;
-import de.nuttercode.androidprojectss2018.csi.query.QueryResultState;
 import de.nuttercode.androidprojectss2018.example.StoreListenerExample;
 
 /**
@@ -30,7 +29,7 @@ public class LBRQueryTest {
 
 		// tagstore for tagfilter testing
 		TagStore tagStore = new TagStore(clientConfiguration);
-		if (tagStore.refresh().getQueryResultState() != QueryResultState.OK)
+		if (!tagStore.refresh().isOK())
 			throw new IllegalStateException();
 		ArrayList<Tag> tags = new ArrayList<>(tagStore.getAll());
 		if (tags.size() < 2)


### PR DESCRIPTION
1. Exceptions am Server werden als QueryResultState an den Client übegeben
2. der Client hat eine neue Methode am QueryResultInformation "isOK()", um den Status des Requests auszuwerten (ansonsten muss zwischen client & server status manuell unterschieden werden - siehe implementation)
3. DBConnection wird geschlossen, wenn LBRServer geschlossen werden
4. es wird nicht mehr endlos im LBRServer auf neue ClientConnections gewartet
5. DBConnection#reconnect wird einmalig aufgerufen, wenn eine SQLException im LBRServer gefangen wird