### PR TITLE
LocalDateTime entfernt

### DIFF
--- a/Backend/src/de/nuttercode/androidprojectss2018/csi/Event.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/csi/Event.java
@@ -1,7 +1,6 @@
 package de.nuttercode.androidprojectss2018.csi;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -19,7 +18,6 @@ public class Event implements Serializable {
 	private final List<Tag> tagList;
 	private String description;
 	private String name;
-	private LocalDateTime localDateTime;
 	private final int id;
 	private final Venue venue;
 
@@ -33,12 +31,11 @@ public class Event implements Serializable {
 	 *             if name is null or empty, if description is null, if or if venue
 	 *             is null
 	 */
-	public Event(Venue venue, String name, String description, int id, LocalDateTime localDateTime) {
+	public Event(Venue venue, String name, String description, int id) {
 		Assurance.assureNotNull(venue);
 		this.tagList = new ArrayList<>();
 		this.id = id;
 		this.venue = venue;
-		setLocalDateTime(localDateTime);
 		setName(name);
 		setDescription(description);
 	}
@@ -71,15 +68,6 @@ public class Event implements Serializable {
 
 	public Venue getVenue() {
 		return venue;
-	}
-
-	public LocalDateTime getLocalDateTime() {
-		return localDateTime;
-	}
-
-	public void setLocalDateTime(LocalDateTime localDateTime) {
-		Assurance.assureNotNull(localDateTime);
-		this.localDateTime = localDateTime;
 	}
 
 	/**
@@ -144,7 +132,7 @@ public class Event implements Serializable {
 	@Override
 	public String toString() {
 		return "Event [tagList=" + Arrays.toString(tagList.toArray()) + ", description=" + description + ", name="
-				+ name + ", localDateTime=" + localDateTime + ", id=" + id + ", venue=" + venue + "]";
+				+ name + ", id=" + id + ", venue=" + venue + "]";
 	}
 
 }

--- a/Backend/src/de/nuttercode/androidprojectss2018/db/DBConnection.java
+++ b/Backend/src/de/nuttercode/androidprojectss2018/db/DBConnection.java
@@ -8,13 +8,15 @@ import de.nuttercode.androidprojectss2018.csi.Venue;
 import java.io.Closeable;
 import java.io.IOException;
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+/*
 import java.sql.Time;
 import java.time.LocalDateTime;
+import java.sql.Date;
+*/
 import java.util.ArrayList;
 import java.util.Properties;
 import java.util.Collection;
@@ -111,7 +113,8 @@ public class DBConnection implements Closeable {
 					dbResult.getString("venue_description"), dbResult.getBigDecimal("longitude").doubleValue(),
 					dbResult.getBigDecimal("latitude").doubleValue(), dbResult.getBigDecimal("distance").doubleValue()),
 					dbResult.getString("event_name"), dbResult.getString("event_description"),
-					dbResult.getInt("event_id"), getLocalDateTime(dbResult.getDate("date"), dbResult.getTime("time"))));
+					dbResult.getInt("event_id")));
+		// , getLocalDateTime(dbResult.getDate("date"), dbResult.getTime("time"))
 		return events;
 	}
 
@@ -217,15 +220,13 @@ public class DBConnection implements Closeable {
 	 *            The SQL Result Time may be null
 	 * @return LocalDateTime with default values if parameters are null
 	 */
-	private static LocalDateTime getLocalDateTime(Date date, Time time) {
-		Date actualDate = date;
-		if (actualDate == null)
-			actualDate = new Date(0);
-		Time actualTime = time;
-		if (actualTime == null)
-			actualTime = new Time(0);
-		return LocalDateTime.of(actualDate.toLocalDate(), actualTime.toLocalTime());
-	}
+	/*
+	 * private static LocalDateTime getLocalDateTime(Date date, Time time) { Date
+	 * actualDate = date; if (actualDate == null) actualDate = new Date(0); Time
+	 * actualTime = time; if (actualTime == null) actualTime = new Time(0); return
+	 * LocalDateTime.of(actualDate.toLocalDate(), actualTime.toLocalTime()); }
+	 * 
+	 */
 
 	/**
 	 * Checks if the Connection was initialized before working on query


### PR DESCRIPTION
LocalDateTime entfernt
Stellen in DBConnection vorerst nur auskommentiert, falls wir das später noch einsetzen wollen

theoretisch könnten wir die alten Klassen aus Java 7 und davor nutzen, also java.util.Date und Time, aber das sind legacy Klassen und ungeeignet. Ansonsten käme bspw. Joda-Time in Frage. Allerdings würde ich das alles vorerst sein lassen, weil wir ja sowieso annehmen, dass alle Events gleichzeitig statt finden.